### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,12 +33,7 @@
   "bugs": {
     "url": "https://github.com/flybysun/pimatic-dewpoint/issues"
   },
-  "licenses": [
-    {
-      "type": "GPLv2",
-      "url": "https://github.com/flybysun/pimatic-dewpoint/blob/master/LICENSE"
-    }
-  ],
+  "license": "GPL-2.0",
   "maintainers": [
     {
       "name": "flybysun",


### PR DESCRIPTION
Revised license information to provide a SPDX 2.0 license identifier in-line with npm v2.1 guidelines on license metadata - see also https://github.com/npm/npm/releases/tag/v2.10.0
